### PR TITLE
Efficiency improvement to code for finding points within the barrier boundary.

### DIFF
--- a/R/BaBA.R
+++ b/R/BaBA.R
@@ -76,7 +76,11 @@ BaBA <-
       sf::st_union()
     
     ## extract points that fall inside the buffer
-    encounter <- sf::st_intersection(animal, barrier_buffer)
+    # st_intersects() is a fast index-based function, so we first get the indices
+    #   of all points that fall within the buffer, then only keep those.
+    inx = sf::st_intersects(animal, barrier_buffer)
+    keep.inx = lapply(inx, length) %>% unlist() > 0
+    encounter <- animal[keep.inx,]
     
     if (nrow(encounter) == 0) stop("no barrier encounter detected.")
     

--- a/R/BaBA.R
+++ b/R/BaBA.R
@@ -268,6 +268,10 @@ BaBA <-
           ## make sure there are enough data to calculate average straightness before and after the encounter event
           ## (w/interval + 1) is the total possible segments if all data are present. 
           ## We define "enough" as at least 1/4 of the total possible segments are present to calculate average straightness.
+          ## Also, make sure that straightnesses is of length enough for sd().
+          if (length(straightnesses_i) <= 1) {
+            warning("Not enough data within window to calculate straightness of track. Either make window w larger, or interval smaller.")
+          }
           if (length(straightnesses_i) >= (w/interval + 1)/4) {
             ## minimum max number possible/2 to calculate sd
             upper <- mean(straightnesses_i) + sd_multiplier * stats::sd(straightnesses_i)


### PR DESCRIPTION
I've suggested two changes here, in separate commits: 

1. Changed st_intersection() to st_intersects().  st_intersection() is slow, I gather, because it can take the intersection of two polygons. When we are dealing with points, though, all we need is a binary "yes/no" that a point is in or not in a polygon. st_intersects() gives us this much faster. See [this discussion](https://gis.stackexchange.com/questions/417210/why-is-there-a-speed-difference-between-sf-intersection-in-r-and-qgis-intersecti) for more info. This change made a run with my dataset (~1M rows) run in 3 seconds instead of 300!
2. While playing around with the st_intersection() problem, I also noticed there's no catch in the code to make sure that we're not running stats::sd() on a vector of length 1; I added that as a second commit just to let the user know their w to interval ratio is off.